### PR TITLE
Fix the Azure Auth Timeout Issue by decreasing the auth token time to 8 minutes

### DIFF
--- a/packages/client/src/app/modules/media/services/azure-recognition.service.ts
+++ b/packages/client/src/app/modules/media/services/azure-recognition.service.ts
@@ -63,7 +63,7 @@ export class AzureRecognitionService {
 					() => {
             this.tokenRefreshTimerId = window.setInterval(() => {
               this._refreshToken()
-            }, (18 * 60 * 1000));
+            }, (8 * 60 * 1000));
 						console.log('recognizer started continuous async', this.isStreaming)
 					},
 					(err: any) => {


### PR DESCRIPTION
Inside `connectToStream()`, the tokenRefreshTimerId was set to trigger every 18 minutes `(18 * 60 * 1000)`. However, Azure Cognitive Services Speech authorization tokens have a strict, non-configurable hard limit of 10 minutes. Because the service waited 18 minutes to request a new token via `_refreshToken()`, the active token had already been expired for 8 minutes, forcing Azure to forcefully close the WebSocket connection. This pull request updates this to 8 minutes so that a new token is requested before the other one can expire. 

In the long run it might be worth adding a self-healing or automatic reconnection logic to gracefully recover from a cancel or closure event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure speech recognition connection stability by optimizing token refresh intervals during continuous recognition sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->